### PR TITLE
Retornando IActionResult no lugar de Unit

### DIFF
--- a/ColecaoLivrosAPIWeb/Controllers/LivroController.cs
+++ b/ColecaoLivrosAPIWeb/Controllers/LivroController.cs
@@ -44,9 +44,9 @@ namespace ColecaoLivrosAPIWeb.Controllers
 
         [HttpPut]
         [Route("{Id}")]
-        public async Task<Unit> PutLivro(long Id, [FromBody] PutLivroCommand putLivroCommand)
+        public async Task<IActionResult> PutLivro(long Id, [FromBody] PutLivroCommand putLivroCommand)
         {
-            return await mediatr.Send(new PutLivroCommand()
+            await mediatr.Send(new PutLivroCommand()
             {
                 Id = Id,
                 NomeLivro = putLivroCommand.NomeLivro,
@@ -54,6 +54,8 @@ namespace ColecaoLivrosAPIWeb.Controllers
                 NumeroPaginas = putLivroCommand.NumeroPaginas,
                 AutorId = putLivroCommand.AutorId
             });
+
+            return Ok();
         }
 
         [HttpDelete]


### PR DESCRIPTION
melhor retornar IActionResult sempre, se precisar retornar um objeto voce retorna um IActionResult<T> só pra ficar tipado quando for colocar um swagger